### PR TITLE
filePathRelativeToWorkspace placeholder added

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Commands support placeholders similar to tasks.json.
 * ${fileDirname}: directory name of saved file
 * ${fileExtname}: extension (including .) of saved file
 * ${fileBasenameNoExt}: saved file's basename without extension
+* ${filePathRelativeToWorkspace}: path of saved file relative to current workspace directory
 
 Samples
 =========

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,6 +139,7 @@ class FileWatcherExtension {
 			const workspaceFolders: vscode.WorkspaceFolder[] | undefined = vscode.workspace.workspaceFolders;
 			const rootPath: string = workspaceFolders?.[0]?.uri.fsPath ?? "";
 			const currentWorkspace: string = vscode.workspace.getWorkspaceFolder(documentUri)?.uri.fsPath ?? "";
+			const filePathRelativeToWorkspace = documentUri.fsPath.replace(currentWorkspace, ''); 
 
 			cmdStr = cmdStr.replace(/\${file}/g, `${documentUri.fsPath}`);
 			cmdStr = cmdStr.replace(/\${workspaceRoot}/g, `${rootPath}`);
@@ -147,6 +148,7 @@ class FileWatcherExtension {
 			cmdStr = cmdStr.replace(/\${fileDirname}/g, `${path.dirname(documentUri.fsPath)}`);
 			cmdStr = cmdStr.replace(/\${fileExtname}/g, `${extName}`);
 			cmdStr = cmdStr.replace(/\${fileBasenameNoExt}/g, `${path.basename(documentUri.fsPath, extName)}`);
+			cmdStr = cmdStr.replace(/\${filePathRelativeToWorkspace}/g, `${filePathRelativeToWorkspace}`);   			
 
 			commands.push({
 				cmd: cmdStr,


### PR DESCRIPTION
There is similar placeholder in phpstorm file watcher plugin. I find it usable when sending commands to docker container