### PR TITLE
[child exec] Show error iff child exits non-zero

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -172,12 +172,14 @@ class FileWatcherExtension {
 			child.stdout?.on("data", data => this._outputChannel.append(data));
 			child.stderr?.on("data", data => {
 				this.showOutputMessage(`[error] ${data}`);
-				this._statusBar.showError();
 			});
 			child.on("exit", () => {
 				this.showOutputMessage(`[${cfg.event}]: for pattern "${cfg.match}" finished`);
 				if (!cfg.isAsync) {
 					this._runCommands(commands);
+				}
+				if (child.exitCode) {
+					this._statusBar.showError();
 				}
 			});
 


### PR DESCRIPTION
Success of the child process is determined by its exit code, not by whether or not it writes to stderr. Also closes #14