### PR TITLE
"onFileChange" should listen on `onDidChangeTextDocument` event

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ function initFileEvents(extension: FileWatcher): void {
     extension.showOutputMessage("[Config reloaded]");
   });
 
-  vscode.workspace.onDidSaveTextDocument(
+  vscode.workspace.onDidChangeTextDocument(
     async (document: vscode.TextDocument) => {
       await extension.eventHandlerAsync({
         event: "onFileChange",


### PR DESCRIPTION
The current implementation listens on `onDidSaveTextDocument` events that is triggered when a file is saved with `Cmd + S` on the file, but it doesn't capture scenario where the file is changed by CLI and actions on the terminal. Changing the listening event to `onDidChangeTextDocument` should also capture those. Are there any concerns on this change?